### PR TITLE
Print action menu

### DIFF
--- a/todos.rb
+++ b/todos.rb
@@ -1,7 +1,7 @@
 todos = [
-  { :id => 1, :content => "Fill the weekly feedback",  :completed => false  },
-  { :id => 2, :content => "Complete Ruby Basics 1",  :completed => false  },
-  { :id => 3, :content => "Complete Ruby Basics 2",  :completed => false  },
+  { id: 1, content: "Fill the weekly feedback", completed: false },
+  { id: 2, content: "Complete Ruby Basics 1",  completed: false  },
+  { id: 3, content: "Complete Ruby Basics 2",  completed: false  }
 ]
 
 def print_actions_menu

--- a/todos.rb
+++ b/todos.rb
@@ -4,4 +4,7 @@ todos = [
   { :id => 3, :content => "Complete Ruby Basics 2",  :completed => false  },
 ]
 
-puts todos
+def print_actions_menu
+  puts "-" * 65
+  puts "add | list | completed | toggle | delete | exit"
+end


### PR DESCRIPTION
1. Se agrega el metodo `print_actions_menu` para imprimir el menu de acciones en la terminal
2. Se ejecuto rubocop y se resolvio 12 ofensas
3. Se modificó la estructura del hash todo para seguir la nueva sintaxis de los hashes:
```{ id: 1, content: "Fill the weekly feedback", completed: false }```